### PR TITLE
Corrige typo no cod do operador ternário

### DIFF
--- a/conteudo/monitoria1.md
+++ b/conteudo/monitoria1.md
@@ -248,7 +248,7 @@ Uma maneira mais curta ainda para problemas com 1 condição é o operador tern�
 ```c
 condition ? (expressão se a condition verdadeira) : (expressão se falsa)
 
-int num2 = num > 0 : 1000 ? -1000;
+int num2 = num > 0 ? 1000 : -1000;
 ```
 
 A condição dentro do _if_ é executada seguindo uma ordem (parentêses, da esquerda para direita), e caso não seja necessário executar tudo para saber se é verdade ou não, o C++ não executa, por exemplo:


### PR DESCRIPTION
Os caracteres trocados na explicação de operador ternário me deixaram bugado por um longo minutinho, então achei interessante avisar :P